### PR TITLE
Add 469 to pull down

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -8,7 +8,7 @@
         <h2>Dyson Pure Link plugin</h2><br/>
         Connects to Dyson Pure Link devices<br/>
         It reads states and sensors (for now), control via commands to be added<br/>
-		Has been tested with type 475, assumed the others (455, 465) work too.<br/>
+		Has been tested with type 475, assumed the others (except 469, see open issue) work too.<br/>
     </description>
     <params>
 		<param field="Address" label="IP Address" width="200px" required="true"/>
@@ -17,6 +17,7 @@
             <options>
                 <option label="455" value="455"/>
                 <option label="465" value="465"/>
+                <option label="469" value="469"/>
                 <option label="475" value="475" default="true"/>
             </options>
         </param>


### PR DESCRIPTION
add 469 to pull down, no additional functionality. Needs to be tested by a model owner.